### PR TITLE
fix(next-auth): remove custom next-auth login path

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -63,9 +63,6 @@ export const authOptions: NextAuthOptions = {
      * @see https://next-auth.js.org/providers/github
      */
   ],
-  pages: {
-    signIn: "/auth/login",
-  },
 };
 
 /**


### PR DESCRIPTION
Removing the custom page for signing in so that NextAuth uses the built-in page for google authorization callbacks.